### PR TITLE
Add `license` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "no-jquery"
   ],
   "version": "1.8.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/nathanboktae/chai-dom"


### PR DESCRIPTION
Besides being shown on npmjs.com, this field is used by license checkers.