### PR TITLE
add rendered option to text matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,17 @@ expect(document.querySelector('#title')).to.contain.html('<em>Tea</em>')
 ```
 
 ### `text(text)`
-Assert that the text of the [HTMLElement][] or combined text of the [NodeList][] is equal to or contains the given text, using [`textContent`][textContent]. You may optionally also provide a `trimmed` chaining flag that will trim this text.
+Assert that the text of the [HTMLElement][] or combined text of the [NodeList][] is equal to or contains the given text, using [`textContent`][textContent]. Chaining flags:
+
+`trimmed`  - will trim the text before comparing\
+`rendered` - will use [`innerText`][innerText] when comparing
 
 ```js
 document.querySelector('.name').should.have.text('John Doe')
 expect(document.querySelector('#title')).to.have.text('Chai Tea')
 document.querySelectorAll('ul li').should.have.text('JohnJaneJessie')
 document.querySelector('h1').should.have.trimmed.text('chai-tests')
+expect(document.querySelector('article')).to.have.rendered.text('Chai Tea is great')
 ```
 
 ```js
@@ -225,5 +229,6 @@ MIT License (see the LICENSE file)
 [HTMLElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
 [NodeList]: https://developer.mozilla.org/en-US/docs/Web/API/NodeList
 [textContent]: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
+[innerText]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText
 [querySelector]: https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector
 [querySelectorAll]: https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll

--- a/chai-dom.js
+++ b/chai-dom.js
@@ -120,17 +120,22 @@
     flag(this, 'trim-text', true)
   })
 
+  chai.Assertion.addChainableMethod('rendered', null, function() {
+    flag(this, 'rendered-text', true)
+  })
+
   chai.Assertion.addMethod('text', function(text) {
     var obj = flag(this, 'object'), contains = flag(this, 'contains'),
         trim = flag(this, 'trim-text'), actual, result
+    var property = flag(this, 'rendered-text') ? 'innerText' : 'textContent'
 
     if (isNodeList(obj)) {
-      actual = Array.prototype.map.call(obj, function(el) { return trim ? el.textContent.trim() : el.textContent })
+      actual = Array.prototype.map.call(obj, function(el) { return trim ? el[property].trim() : el[property] })
       if (Array.isArray(text)) {
         result = contains ?
           text[flag(this, 'negate') ? 'some' : 'every'](function(t) {
             return Array.prototype.some.call(obj, function(el) {
-              return (trim ? el.textContent.trim() : el.textContent) === t
+              return (trim ? el[property].trim() : el[property]) === t
             })
           })
           :
@@ -143,11 +148,21 @@
         result = contains ? actual.indexOf(text) >= 0 : actual === text
       }
     } else {
-      actual = trim ? obj.textContent.trim() : obj.textContent
+      actual = trim ? obj[property].trim() : obj[property]
       result = contains ? actual.indexOf(text) >= 0 : actual === text
     }
 
-    var objDesc = elToString(obj), textMsg = trim ? 'trimmed text' : 'text'
+    var objDesc = elToString(obj)
+    var textMsg = ''
+
+    if (trim) {
+      textMsg += 'trimmed '
+    }
+    if (flag(this, 'rendered-text')) {
+      textMsg += 'rendered '
+    }
+    textMsg += 'text'
+
     if (contains) {
       this.assert(
         result


### PR DESCRIPTION
Unfortunately I was not able to add tests, because phantomjs does not seem to implement innerText correctly. I think it might make sense to update to use some kind of test harness like testem.js and headless Chrome to run the tests. I could work on getting that updated if you 're interested.