### PR TITLE
Add 'focus' assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ document.querySelector('.container').should.have.style('color', 'rgb(55, 66, 77)
 expect(document.querySelector('.container')).not.to.have.style('borderWidth', '3px')
 ```
 
+### `focus`
+
+Assert that the [HTMLElement][] has set focus.
+
+```js
+document.querySelector('input').should.have.focus
+expect(document.querySelector('.container')).not.to.have.focus
+```
+
 ## Installation
 
 ### npm

--- a/chai-dom.js
+++ b/chai-dom.js
@@ -386,4 +386,19 @@
       , actual
     )
   })
+
+  chai.Assertion.overwriteProperty('focus', function() {
+    return function () {
+      var el = flag(this, 'object'), actual = el.ownerDocument.activeElement
+
+      this.assert(
+        el === el.ownerDocument.activeElement
+        , 'expected #{this} to have focus'
+        , 'expected #{this} not to have focus'
+        , el
+        , actual
+      )
+
+    }
+  })
 }));

--- a/test/tests.js
+++ b/test/tests.js
@@ -897,6 +897,7 @@ describe('DOM assertions', function() {
       hiddenViaCSS.should.not.be.visible
       collapsedViaCSS.should.not.be.visible
     })
+
     it('fails when the element has visibility: hidden', function() {
       (function() {
         hiddenViaStyle.should.be.visible

--- a/test/tests.js
+++ b/test/tests.js
@@ -897,7 +897,6 @@ describe('DOM assertions', function() {
       hiddenViaCSS.should.not.be.visible
       collapsedViaCSS.should.not.be.visible
     })
-
     it('fails when the element has visibility: hidden', function() {
       (function() {
         hiddenViaStyle.should.be.visible
@@ -997,5 +996,42 @@ describe('DOM assertions', function() {
       chai.util.elToString(div.querySelectorAll('p'))
         .should.equal('p#nlt1, p#nlt2, p#nlt3, p#nlt4, p#nlt5... (+3 more)')
     })
+  })
+
+  describe('focus', function() {
+    var container = document.getElementById("mocha");
+    var focused = parse('<input type="text" id="focused" name="focused">');
+    var blurred = parse('<input type="text" id="blurred" name="blurred">');
+
+    beforeEach(function() {
+      container.appendChild(focused)
+      container.appendChild(blurred)
+      focused.focus();
+    });
+
+    afterEach(function() {
+      container.removeChild(focused)
+      container.removeChild(blurred)
+    });
+
+    it("passes when the element has focus", function(){
+      focused.should.have.focus;
+    });
+
+    it("passes negated when the element does not have focus", function(){
+      blurred.should.not.have.focus;
+    });
+
+    it("fails when the element does not have focus", function(){
+      (function(){
+        blurred.should.have.focus;
+      }).should.fail("expected " + inspect(blurred) + " to have focus");
+    });
+
+    it("fails negated when element has focus", function(){
+      (function(){
+        focused.should.not.have.focus;
+      }).should.fail("expected " + inspect(focused) + " not to have focus");
+    });
   })
 })


### PR DESCRIPTION
While reading documentation I noticed that [chai-jquery](https://www.chaijs.com/plugins/chai-jquery/) has `focus` assertion and I was surprised that this fork doesn't have it.
I thought I could add it because it's more convenient than typing the code.