### PR TITLE
Add regex support for `.class` assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ document.getElementsByName('bar').should.have.class('foo')
 expect(document.querySelector('main article')).to.have.class('foo')
 ```
 
+Also accepts regex as argument.
+
+```js
+document.getElementsByName('bar').should.have.class(/foo/)
+expect(document.querySelector('main article')).to.have.class(/foo/)
+```
+
 ### `id(id)`
 Assert that the [HTMLElement][] has the given id.
 

--- a/chai-dom.js
+++ b/chai-dom.js
@@ -79,6 +79,16 @@
 
   chai.Assertion.addMethod('class', function(className) {
     var el = flag(this, 'object')
+
+    if (className instanceof RegExp) {
+      return this.assert(
+        Array.from(el.classList).some(function(cls) { return className.test(cls) })
+        , 'expected ' + elToString(el) + ' to have class matching #{exp}'
+        , 'expected ' + elToString(el) + ' not to have class matching #{exp}'
+        , className
+      )
+    } 
+    
     this.assert(
       el.classList.contains(className)
       , 'expected ' + elToString(el) + ' to have class #{exp}'

--- a/test/tests.js
+++ b/test/tests.js
@@ -132,8 +132,16 @@ describe('DOM assertions', function() {
       subject.should.have.class('baz');
     })
 
+    it('passes when the element has the class matching given regex', function () {
+      subject.should.have.class(/foo/)
+    })
+
     it('passes negated when the element does not have the class', function() {
       subject.should.not.have.class('bar')
+    })
+
+    it('passes negated when the element does not have the class matching given regex', function () {
+      subject.should.not.have.class(/bar/)
     })
 
     it('fails when the element does not have the class', function() {
@@ -142,10 +150,22 @@ describe('DOM assertions', function() {
       }).should.fail('expected div.foo.shazam.baz to have class \'bar\'')
     })
 
+    it('fails when the element does not have the class matching given regex', function() {
+      (function() {
+        subject.should.have.class(/bar/)
+      }).should.fail('expected div.foo.shazam.baz to have class matching /bar/')
+    })
+
     it('fails negated when the element has the class', function() {
       (function() {
         subject.should.not.have.class('foo')
       }).should.fail('expected div.foo.shazam.baz not to have class \'foo\'')
+    })
+
+    it('fails negated when the element has the class matching given regex', function() {
+      (function() {
+        subject.should.not.have.class(/foo/)
+      }).should.fail('expected div.foo.shazam.baz not to have class matching /foo/')
     })
   })
 


### PR DESCRIPTION
Assert a class name against certain regex.

```js
parse('<div class="foo shazam  baz"></div>').should.have.class(/foo/)
```