### PR TITLE
Allow `style` function to test CSS variables

### DIFF
--- a/chai-dom.js
+++ b/chai-dom.js
@@ -387,7 +387,7 @@
   chai.Assertion.addMethod('style', function (styleProp, styleValue) {
     var el = flag(this, 'object'),
         style = window.getComputedStyle(el),
-        actual = style.getPropertyValue(styleProp);
+        actual = style.getPropertyValue(styleProp).trim();
 
     this.assert(
       actual === styleValue

--- a/chai-dom.js
+++ b/chai-dom.js
@@ -387,7 +387,7 @@
   chai.Assertion.addMethod('style', function (styleProp, styleValue) {
     var el = flag(this, 'object'),
         style = window.getComputedStyle(el),
-        actual = style[styleProp];
+        actual = style.getPropertyValue(styleProp);
 
     this.assert(
       actual === styleValue


### PR DESCRIPTION
Indexing a computed style does not allow to read CSS variables. Using `getPropertyValue` allows to get "normal" CSS properties as well as variables.

Furthermore the value of the property is not trimmed, since we had some tests fail due to the properties being `[whitespace]#123456`. The whitespace makes no functional difference to CSS but found that they are undesirable to include in the testing logic.

Thank you for your time!

